### PR TITLE
Add domain documentation

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,12 @@
+# Domain Documentation
+
+This directory contains high-level overviews of the main domains in the CRM application. Each subfolder summarizes the backend controllers, models, jobs, and services along with the relevant frontend pages, components, services, and stores.
+
+## Domains
+- **auth** – user authentication and registration
+- **teams** – team management and membership
+- **invitations** – invitation tokens and flows
+- **organizations** – organization records and browsing
+- **scrapers** – importing and scraping data via external services
+
+Use these documents as quick context for AI coding agents working within each domain.

--- a/docs/auth/README.md
+++ b/docs/auth/README.md
@@ -1,0 +1,13 @@
+# Auth Domain
+
+## Purpose
+Manages user authentication including standard registration, invitation-based signup, login, logout and fetching the current user.
+
+## Backend
+- **AuthController**: provides endpoints for registering, logging in, logging out and retrieving the current user. Handles invitation tokens during registration and creates a default team for new users.
+- **User model**: stores account details and relationships to teams.
+- **InvitationToken model**: tracks pending invitations that can be redeemed during registration.
+
+## Frontend
+- **Pages**: `resources/js/pages/auth/Login.vue` and `resources/js/pages/auth/Register.vue` implement the login and registration forms. Registration accepts an optional invitation token from the URL.
+- **Service**: `resources/js/services/auth.js` wraps authentication API calls and persists tokens in `localStorage`.

--- a/docs/invitations/README.md
+++ b/docs/invitations/README.md
@@ -1,0 +1,14 @@
+# Invitations Domain
+
+## Purpose
+Manages invitation tokens used to invite users to teams and allow token-based registration.
+
+## Backend
+- **InvitationController**: verifies invitation tokens before registration.
+- **InvitationToken model**: stores invitation details, associated team and expiration.
+- **AuthController**: processes registration requests that include a valid invitation token.
+- **TeamController**: issues invitations, and provides endpoints to accept or decline them.
+
+## Frontend
+- **Registration page** (`resources/js/pages/auth/Register.vue`): accepts an invitation token via query string and submits it during signup.
+- **Team pages and store**: `resources/js/pages/teams/Index.vue`, `resources/js/pages/teams/Show.vue` and `resources/js/stores/teamStore.js` display pending invitations and allow members to accept or decline.

--- a/docs/organizations/README.md
+++ b/docs/organizations/README.md
@@ -1,0 +1,14 @@
+# Organizations Domain
+
+## Purpose
+Stores businesses or clients in the CRM and provides browsing, creation and editing interfaces.
+
+## Backend
+- **OrganizationController**: supports listing with filters, viewing details, creating, updating, deleting and restoring organizations.
+- **Organization model**: represents an organization with address, contact and rating data; related `Page` records hold scraped website pages.
+- **OrganizationImportService**: maps external scraper results into organization records.
+
+## Frontend
+- **Pages**: `resources/js/pages/organizations/Index.vue` and `Browse.vue` list organizations; `Show.vue` displays details; `Create.vue` and `Edit.vue` handle forms; `Import.vue` triggers scraper-based imports.
+- **Components**: `resources/js/components/OrganizationForm.vue` and `OrganizationFilters.vue` share form and filter UI.
+- **Store**: `resources/js/stores/organizationStore.js` manages organization data, filters and pagination.

--- a/docs/scrapers/README.md
+++ b/docs/scrapers/README.md
@@ -1,0 +1,14 @@
+# Scrapers Domain
+
+## Purpose
+Interfaces with external scraping services to import organization data and crawl websites.
+
+## Backend
+- **Controllers**: `GoogleMapsScraperController` starts Google Maps imports and lists their status; `WebScraperController` starts website crawls and reports run details.
+- **Jobs**: `StartApifyScrapingJob`, `MonitorApifyRunJob`, `ProcessApifyResultsJob`, `StartWebScrapingJob`, `MonitorWebScrapingJob`, and `ProcessWebScrapingResultsJob` orchestrate asynchronous scraping workflows.
+- **Services**: `BaseApifyService` wraps API calls; `GoogleMapsScraperService` and `PuppeteerCrawlerService` launch and monitor Apify actors; `OrganizationImportService` maps scraped results into organization records.
+- **Model**: `ApifyRun` stores metadata and progress for each scraping run.
+
+## Frontend
+- **Page**: `resources/js/pages/organizations/Import.vue` lets users start Google Maps imports and view run history.
+- **Store**: `resources/js/stores/apifyImportStore.js` manages import requests and pagination of past runs.

--- a/docs/teams/README.md
+++ b/docs/teams/README.md
@@ -1,0 +1,13 @@
+# Teams Domain
+
+## Purpose
+Handles creation of teams, membership management and role assignments.
+
+## Backend
+- **TeamController**: provides endpoints for listing teams, creating and updating teams, inviting users, accepting or declining invitations, removing members and changing member roles.
+- **Team model**: represents a team owned by a user and linked to members through a pivot table.
+- **InvitationToken model** and **Mailable classes** (`NewUserTeamInvitation`, `TeamInvitation`): support sending and tracking invitations.
+
+## Frontend
+- **Pages**: `resources/js/pages/teams/Index.vue` lists teams and allows creation; `resources/js/pages/teams/Show.vue` displays team details, members and pending invitations.
+- **Store**: `resources/js/stores/teamStore.js` fetches teams, manages invitations and membership actions.


### PR DESCRIPTION
## Summary
- document domains for auth, teams, invitations, organizations and scrapers
- provide root docs index for AI context

## Testing
- `npm test` (fails: Missing script "test")
- `./vendor/bin/pest` (fails: MissingAppKeyException)


------
https://chatgpt.com/codex/tasks/task_b_68b0b7a4c6fc8323a4f1a906a5823b2e