### PR TITLE
Introduce organization categories with CRUD and import sync

### DIFF
--- a/app/Http/Controllers/OrganizationCategoryController.php
+++ b/app/Http/Controllers/OrganizationCategoryController.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Models\OrganizationCategory;
+use Illuminate\Http\Request;
+
+class OrganizationCategoryController extends Controller
+{
+    public function index()
+    {
+        return OrganizationCategory::orderBy('name')->get();
+    }
+
+    public function store(Request $request)
+    {
+        $validated = $request->validate([
+            'name' => 'required|string|max:100|unique:organization_categories,name',
+        ]);
+
+        $category = OrganizationCategory::create($validated);
+        return response()->json($category, 201);
+    }
+
+    public function update(Request $request, OrganizationCategory $organizationCategory)
+    {
+        $validated = $request->validate([
+            'name' => 'required|string|max:100|unique:organization_categories,name,' . $organizationCategory->id,
+        ]);
+
+        $organizationCategory->update($validated);
+        return response()->json($organizationCategory);
+    }
+
+    public function destroy(OrganizationCategory $organizationCategory)
+    {
+        $organizationCategory->delete();
+        return response()->json(['message' => 'Category deleted']);
+    }
+}

--- a/app/Models/Organization.php
+++ b/app/Models/Organization.php
@@ -4,8 +4,10 @@ namespace App\Models;
 
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Database\Eloquent\SoftDeletes;
+use App\Models\OrganizationCategory;
 
 class Organization extends Model
 {
@@ -24,7 +26,7 @@ class Organization extends Model
         'website',
         'website_rating',
         'phone',
-        'category',
+        'organization_category_id',
         'map_url',
         'notes',
     ];
@@ -57,17 +59,24 @@ class Organization extends Model
     public function scopeByLocation($query, $city = null, $state = null)
     {
         if ($city) {
-            $query->where('city', 'LIKE', "%{$city}%");
+            $query->where('organizations.city', 'LIKE', "%{$city}%");
         }
         if ($state) {
-            $query->where('state', 'LIKE', "%{$state}%");
+            $query->where('organizations.state', 'LIKE', "%{$state}%");
         }
         return $query;
     }
 
+    public function category(): BelongsTo
+    {
+        return $this->belongsTo(OrganizationCategory::class, 'organization_category_id');
+    }
+
     public function scopeByCategory($query, $category)
     {
-        return $query->where('category', 'LIKE', "%{$category}%");
+        return $query->whereHas('category', function ($q) use ($category) {
+            $q->where('name', 'LIKE', "%{$category}%");
+        });
     }
 
     public function pages(): HasMany

--- a/app/Models/OrganizationCategory.php
+++ b/app/Models/OrganizationCategory.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\HasMany;
+
+class OrganizationCategory extends Model
+{
+    use HasFactory;
+
+    protected $fillable = ['name'];
+
+    public function organizations(): HasMany
+    {
+        return $this->hasMany(Organization::class);
+    }
+}

--- a/app/Services/OrganizationImportService.php
+++ b/app/Services/OrganizationImportService.php
@@ -3,6 +3,7 @@
 namespace App\Services;
 
 use App\Models\Organization;
+use App\Models\OrganizationCategory;
 use App\Models\ApifyRun;
 use Illuminate\Support\Facades\Log;
 
@@ -89,9 +90,17 @@ class OrganizationImportService
             'country_code' => $item['countryCode'] ?? null,
             'website' => $this->normalizeWebsite($item['website'] ?? null),
             'phone' => $item['phone'] ?? null,
-            'category' => $item['categoryName'] ?? null,
+            'organization_category_id' => $this->resolveCategoryId($item['categoryName'] ?? null),
             'map_url' => $item['url'] ?? null,
         ];
+    }
+
+    private function resolveCategoryId(?string $name): ?int
+    {
+        if (!$name) {
+            return null;
+        }
+        return OrganizationCategory::firstOrCreate(['name' => $name])->id;
     }
 
     /**

--- a/database/migrations/2025_08_04_000000_create_organization_categories_table.php
+++ b/database/migrations/2025_08_04_000000_create_organization_categories_table.php
@@ -1,0 +1,22 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('organization_categories', function (Blueprint $table) {
+            $table->id();
+            $table->string('name')->unique();
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('organization_categories');
+    }
+};

--- a/database/migrations/2025_08_05_000001_create_organizations_table.php
+++ b/database/migrations/2025_08_05_000001_create_organizations_table.php
@@ -21,14 +21,13 @@ return new class extends Migration
             $table->string('country_code', 2)->nullable();
             $table->string('website')->nullable();
             $table->string('phone')->nullable();
-            $table->string('category')->nullable();
+            $table->foreignId('organization_category_id')->nullable()->constrained('organization_categories');
             $table->text('map_url')->nullable();
             $table->text('notes')->nullable();
             $table->timestamps();
             $table->softDeletes();
 
             $table->index(['city', 'state']);
-            $table->index('category');
             $table->index('deleted_at');
         });
     }

--- a/docs/organizations/README.md
+++ b/docs/organizations/README.md
@@ -5,10 +5,13 @@ Stores businesses or clients in the CRM and provides browsing, creation and edit
 
 ## Backend
 - **OrganizationController**: supports listing with filters, viewing details, creating, updating, deleting and restoring organizations.
+- **OrganizationCategoryController**: CRUD for reusable organization categories.
 - **Organization model**: represents an organization with address, contact and rating data; related `Page` records hold scraped website pages.
-- **OrganizationImportService**: maps external scraper results into organization records.
+- **OrganizationCategory model**: labels organizations and is created automatically during imports.
+- **OrganizationImportService**: maps external scraper results into organization records and syncs categories.
 
 ## Frontend
 - **Pages**: `resources/js/pages/organizations/Index.vue` and `Browse.vue` list organizations; `Show.vue` displays details; `Create.vue` and `Edit.vue` handle forms; `Import.vue` triggers scraper-based imports.
+- **Organization Categories**: `resources/js/pages/organization-categories/Index.vue` manages category records.
 - **Components**: `resources/js/components/OrganizationForm.vue` and `OrganizationFilters.vue` share form and filter UI.
 - **Store**: `resources/js/stores/organizationStore.js` manages organization data, filters and pagination.

--- a/resources/js/components/AppNav.vue
+++ b/resources/js/components/AppNav.vue
@@ -22,6 +22,7 @@ const logout = async () => {
                     <router-link to="/" class="text-sm hover:text-neutral-300">Dashboard</router-link>
                     <router-link to="/organizations" class="text-sm hover:text-neutral-300">Organizations</router-link>
                     <router-link to="/teams" class="text-sm hover:text-neutral-300">Teams</router-link>
+                    <router-link to="/organization-categories" class="text-sm hover:text-neutral-300">Categories</router-link>
                 </div>
             </div>
 

--- a/resources/js/components/OrganizationForm.vue
+++ b/resources/js/components/OrganizationForm.vue
@@ -1,7 +1,8 @@
 <script setup>
-import { ref, watch } from 'vue';
+import { ref, watch, onMounted } from 'vue';
 import Button from '@/components/ui/Button.vue';
 import Input from '@/components/ui/Input.vue';
+import api from '@/services/api';
 
 const props = defineProps({
   organization: {
@@ -27,7 +28,7 @@ const form = ref({
   country_code: '',
   website: '',
   phone: '',
-  category: '',
+  organization_category_id: '',
   notes: '',
 });
 
@@ -38,8 +39,20 @@ watch(() => props.organization, (newOrg) => {
     Object.keys(form.value).forEach(key => {
       form.value[key] = newOrg[key] || '';
     });
+    if (newOrg.category) {
+      form.value.organization_category_id = newOrg.category.id;
+    }
   }
 }, { immediate: true });
+
+const categories = ref([]);
+onMounted(async () => {
+  try {
+    categories.value = await api.get('/organization-categories');
+  } catch (e) {
+    console.error('Failed to load categories', e);
+  }
+});
 
 const submitForm = () => {
   errors.value = {};
@@ -67,7 +80,13 @@ const validateWebsite = () => {
         
         <div>
           <label class="block text-sm font-medium text-neutral-700 mb-1">Category</label>
-          <Input v-model="form.category" placeholder="e.g., Insurance Agency" />
+          <select
+            v-model="form.organization_category_id"
+            class="w-full px-3 py-2 border border-neutral-300 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500"
+          >
+            <option value="">None</option>
+            <option v-for="cat in categories" :key="cat.id" :value="cat.id">{{ cat.name }}</option>
+          </select>
         </div>
         
         <div>

--- a/resources/js/pages/organization-categories/Index.vue
+++ b/resources/js/pages/organization-categories/Index.vue
@@ -1,0 +1,76 @@
+<script setup>
+import { ref, onMounted } from 'vue';
+import DefaultLayout from '@/layouts/DefaultLayout.vue';
+import Button from '@/components/ui/Button.vue';
+import Input from '@/components/ui/Input.vue';
+import api from '@/services/api';
+
+const categories = ref([]);
+const newCategory = ref('');
+const editingId = ref(null);
+const editingName = ref('');
+
+const fetchCategories = async () => {
+  categories.value = await api.get('/organization-categories');
+};
+
+onMounted(fetchCategories);
+
+const createCategory = async () => {
+  if (!newCategory.value) return;
+  await api.post('/organization-categories', { name: newCategory.value });
+  newCategory.value = '';
+  await fetchCategories();
+};
+
+const startEdit = (category) => {
+  editingId.value = category.id;
+  editingName.value = category.name;
+};
+
+const updateCategory = async (id) => {
+  await api.put(`/organization-categories/${id}`, { name: editingName.value });
+  editingId.value = null;
+  editingName.value = '';
+  await fetchCategories();
+};
+
+const deleteCategory = async (id) => {
+  await api.delete(`/organization-categories/${id}`);
+  await fetchCategories();
+};
+</script>
+
+<template>
+  <DefaultLayout>
+    <div class="container mx-auto py-8 px-4">
+      <h1 class="text-2xl font-bold mb-6">Organization Categories</h1>
+      <div class="mb-6 flex space-x-2">
+        <Input v-model="newCategory" placeholder="New category name" />
+        <Button @click="createCategory">Add</Button>
+      </div>
+      <div class="bg-white rounded-lg shadow-sm border border-neutral-200">
+        <table class="min-w-full divide-y divide-neutral-200">
+          <tbody class="divide-y divide-neutral-200">
+            <tr v-for="cat in categories" :key="cat.id" class="hover:bg-neutral-50">
+              <td class="px-4 py-3">
+                <div v-if="editingId === cat.id" class="flex space-x-2">
+                  <Input v-model="editingName" />
+                  <Button @click="updateCategory(cat.id)">Save</Button>
+                  <Button variant="outline" @click="editingId = null">Cancel</Button>
+                </div>
+                <div v-else class="flex justify-between items-center">
+                  <span>{{ cat.name }}</span>
+                  <div class="space-x-2">
+                    <Button variant="outline" @click="startEdit(cat)">Edit</Button>
+                    <Button variant="outline" @click="deleteCategory(cat.id)">Delete</Button>
+                  </div>
+                </div>
+              </td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+    </div>
+  </DefaultLayout>
+</template>

--- a/resources/js/pages/organizations/Browse.vue
+++ b/resources/js/pages/organizations/Browse.vue
@@ -146,7 +146,7 @@ const updateWebsiteRating = async (organizationId, rating) => {
                             </div>
 
                             <div v-if="organization.category" class="text-sm text-neutral-600 mb-2">
-                                {{ organization.category }}
+                                {{ organization.category.name }}
                             </div>
 
                             <div v-if="organization.city || organization.state" class="text-sm text-neutral-500 mb-3">

--- a/resources/js/pages/organizations/Index.vue
+++ b/resources/js/pages/organizations/Index.vue
@@ -131,7 +131,7 @@ const startWebScraping = async (organization) => {
                                     </div>
                                 </td>
                                 <td class="px-6 py-4 whitespace-nowrap text-sm text-neutral-900">
-                                    {{ organization.category || '-' }}
+                                    {{ organization.category?.name || '-' }}
                                 </td>
                                 <td class="px-6 py-4 whitespace-nowrap text-sm text-neutral-900">
                                     <div>{{ organization.city || '-' }}</div>

--- a/resources/js/pages/organizations/Show.vue
+++ b/resources/js/pages/organizations/Show.vue
@@ -52,7 +52,7 @@ const deleteOrganization = async () => {
             </router-link>
             <h1 class="text-3xl font-bold text-neutral-900">{{ organizationStore.currentOrganization.name }}</h1>
             <p v-if="organizationStore.currentOrganization.category" class="text-lg text-neutral-600 mt-1">
-              {{ organizationStore.currentOrganization.category }}
+              {{ organizationStore.currentOrganization.category.name }}
             </p>
           </div>
           <div class="flex space-x-2">
@@ -123,7 +123,7 @@ const deleteOrganization = async () => {
               <div class="space-y-3">
                 <div v-if="organizationStore.currentOrganization.category">
                   <span class="text-sm font-medium text-neutral-700">Category:</span>
-                  <span class="ml-2 text-sm text-neutral-900">{{ organizationStore.currentOrganization.category }}</span>
+                  <span class="ml-2 text-sm text-neutral-900">{{ organizationStore.currentOrganization.category.name }}</span>
                 </div>
                 
                 <div v-if="organizationStore.currentOrganization.city">

--- a/resources/js/router/index.js
+++ b/resources/js/router/index.js
@@ -13,6 +13,7 @@ import OrganizationShow from '@/pages/organizations/Show.vue'
 import OrganizationCreate from '@/pages/organizations/Create.vue'
 import OrganizationEdit from '@/pages/organizations/Edit.vue'
 import OrganizationImport from '@/pages/organizations/Import.vue'
+import OrganizationCategoriesIndex from '@/pages/organization-categories/Index.vue'
 
 const routes = [
     {
@@ -79,6 +80,12 @@ const routes = [
         path: '/organizations/:id/edit',
         name: 'organizations.edit',
         component: OrganizationEdit,
+        meta: { requiresAuth: true }
+    },
+    {
+        path: '/organization-categories',
+        name: 'organization-categories.index',
+        component: OrganizationCategoriesIndex,
         meta: { requiresAuth: true }
     }
 ]

--- a/routes/api.php
+++ b/routes/api.php
@@ -5,6 +5,7 @@ use App\Http\Controllers\AuthController;
 use App\Http\Controllers\InvitationController;
 use App\Http\Controllers\TeamController;
 use App\Http\Controllers\OrganizationController;
+use App\Http\Controllers\OrganizationCategoryController;
 use App\Http\Controllers\GoogleMapsScraperController;
 use App\Http\Controllers\WebScraperController;
 
@@ -30,6 +31,11 @@ Route::middleware('auth:sanctum')->group(function () {
     // Organization routes
     Route::resource('organizations', OrganizationController::class);
     Route::post('organizations/{id}/restore', [OrganizationController::class, 'restore']);
+
+    // Organization category routes
+    Route::resource('organization-categories', OrganizationCategoryController::class)->only([
+        'index', 'store', 'update', 'destroy'
+    ]);
 
     // Apify import routes
     Route::prefix('apify')->group(function () {


### PR DESCRIPTION
## Summary
- add `OrganizationCategory` model, controller, migration and API routes
- link organizations to categories and create them during imports
- expose category management page and selection in organization forms

## Testing
- `APP_KEY=base64:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa php artisan test` *(fails: Vite manifest not found)*

------
https://chatgpt.com/codex/tasks/task_b_68b30102bb9c832383c379e5cc66a45c